### PR TITLE
Refactor helper funcs to file, add query tests

### DIFF
--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -84,6 +84,9 @@ func helperFloatEquals(x float64, y float64) bool {
 
 func helperCheckStatisticalCorrect(points []btrdb.RawPoint, statPoints []btrdb.StatPoint, queryWidth int64) error {
 	pointsIndex := 0
+	if len(statPoints) == 0 {
+		return fmt.Errorf("Given stat point slice was empty")
+	}
 	for _, sp := range statPoints {
 		endtime := sp.Time + int64(queryWidth)
 		count := uint64(0)

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -1,0 +1,167 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/pborman/uuid"
+
+	"gopkg.in/BTrDB/btrdb.v4"
+)
+
+func helperConnect(t *testing.T, ctx context.Context) *btrdb.BTrDB {
+	db, err := btrdb.Connect(ctx, btrdb.EndpointsFromEnv()...)
+	if err != nil {
+		t.Fatalf("Unexpected connection error: %v", err)
+	}
+	return db
+}
+
+func helperGetCollection(uu uuid.UUID) string {
+	return fmt.Sprintf("test.%x", uu[:])
+}
+
+func helperCreateStream(t *testing.T, ctx context.Context, db *btrdb.BTrDB, uu uuid.UUID, coll string, tags map[string]string, ann map[string]string) *btrdb.Stream {
+	stream, err := db.Create(ctx, uu, coll, tags, ann)
+	if err != nil {
+		t.Fatalf("create error %v", err)
+	}
+	return stream
+}
+
+func helperCreateDefaultStream(t *testing.T, ctx context.Context, db *btrdb.BTrDB, tags map[string]string, ann map[string]string) *btrdb.Stream {
+	uu := uuid.NewRandom()
+	coll := helperGetCollection(uu)
+	s := helperCreateStream(t, ctx, db, uu, coll, tags, ann)
+	suu := s.UUID()
+	if len(suu) != len(uu) {
+		t.Fatal("Bad UUID")
+	}
+	for i, b := range suu {
+		if b != uu[i] {
+			t.Fatal("UUID of created stream does not match provided UUID")
+		}
+	}
+	return s
+}
+
+func helperWaitAfterInsert(t *testing.T, ctx context.Context, s *btrdb.Stream) {
+	err := s.Flush(ctx)
+	if err != nil {
+		t.Fatalf("Error from Flush %v", err)
+	}
+}
+
+func helperInsert(t *testing.T, ctx context.Context, s *btrdb.Stream, data []btrdb.RawPoint) {
+	err := s.Insert(ctx, data)
+	if err != nil {
+		t.Fatalf("Error from Insert %v", err)
+	}
+	helperWaitAfterInsert(t, ctx, s)
+}
+
+func helperRandomData(start int64, end int64, gap int64) []btrdb.RawPoint {
+	numpts := (end - start) / gap
+	pts := make([]btrdb.RawPoint, numpts)
+	for i, _ := range pts {
+		pts[i].Time = start + (int64(i) * gap)
+		pts[i].Value = rand.NormFloat64()
+	}
+	return pts
+}
+
+func helperRandomDataCount(start int64, end int64, numpts int64) []btrdb.RawPoint {
+	gap := (end - start) / numpts
+	return helperRandomData(start, end, gap)
+}
+
+func helperFloatEquals(x float64, y float64) bool {
+	return math.Abs(x-y) < 1e-10*math.Max(math.Abs(x), math.Abs(y))
+}
+
+func helperCheckStatisticalCorrect(points []btrdb.RawPoint, statPoints []btrdb.StatPoint, queryWidth int64) error {
+	pointsIndex := 0
+	for _, sp := range statPoints {
+		endtime := sp.Time + int64(queryWidth)
+		count := uint64(0)
+		min := math.Inf(1)
+		max := math.Inf(-1)
+		sum := 0.0
+		fmt.Println(sp.Time)
+		for pointsIndex < len(points) && points[pointsIndex].Time < endtime {
+			point := &points[pointsIndex]
+			if point.Time < sp.Time || point.Time > sp.Time+queryWidth {
+				return fmt.Errorf("Point at index %v time %v was out of range %v-%v", pointsIndex, point.Time, sp.Time, sp.Time+queryWidth)
+			}
+			min = math.Min(min, point.Value)
+			sum += point.Value
+			max = math.Max(max, point.Value)
+			count++
+			pointsIndex++
+		}
+		if min == math.Inf(1) {
+			fmt.Printf("index %v sp %v", sp, points[pointsIndex])
+		}
+		mean := sum / float64(count)
+		if min != sp.Min {
+			return fmt.Errorf("Calculated min %v did not equal stat point min %v", min, sp.Min)
+		}
+		if max != sp.Max {
+			return fmt.Errorf("Calculated max %v did not equal stat point max %v", max, sp.Max)
+		}
+		if count != sp.Count {
+			return fmt.Errorf("Calculated point count %v did not equal stat point count %v", count, sp.Count)
+		}
+		if !helperFloatEquals(mean, sp.Mean) {
+			return fmt.Errorf("Calculated mean %v did not equal stat point mean %v", mean, sp.Mean)
+		}
+	}
+	return nil
+}
+
+func helperCheckStatisticalEqual(a []btrdb.StatPoint, b []btrdb.StatPoint) error {
+	if len(a) != len(b) {
+		return fmt.Errorf("Stat point lenghts did not match %v %v", len(a), len(b))
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return fmt.Errorf("Stat point %v is not equal to %v", a[i], b[i])
+		}
+	}
+
+	return nil
+}
+
+func helperWindowQuery(t *testing.T, ctx context.Context, s *btrdb.Stream, start int64, end int64, width uint64, depth uint8, version uint64) ([]btrdb.StatPoint, uint64) {
+	spc, verc, errc := s.Windows(ctx, start, end, width, depth, version)
+	rv := make([]btrdb.StatPoint, 0)
+	for sp := range spc {
+		rv = append(rv, sp)
+	}
+	ver := <-verc
+	err := <-errc
+	if err != nil {
+		t.Fatalf("window query error: %v", err)
+	}
+
+	return rv, ver
+}
+
+func helperStatisticalQuery(t *testing.T, ctx context.Context, s *btrdb.Stream, start int64, end int64, pwe uint8, version uint64) ([]btrdb.StatPoint, uint64) {
+	spc, verc, errc := s.AlignedWindows(ctx, start, end, pwe, version)
+	rv := make([]btrdb.StatPoint, 0)
+	for sp := range spc {
+		rv = append(rv, sp)
+	}
+	ver := <-verc
+	err := <-errc
+	if err != nil {
+		t.Fatalf("statistical query error: %v", err)
+	}
+
+	return rv, ver
+}

--- a/tests/window_query_test.go
+++ b/tests/window_query_test.go
@@ -26,7 +26,7 @@ func RunTestQueryWithHoles(t *testing.T, query QueryFunc) {
 	allData := make([]btrdb.RawPoint, 0)
 	allData = append(allData, firstData...)
 	allData = append(allData, secondData...)
-	err := helperCheckStatisticalCorrect(allData, spts, int64(width))
+	err := helperCheckStatisticalCorrect(allData, spts, start, int64(width))
 	if err != nil {
 		t.Fatalf("Queried data was invalid: %v", err)
 	}
@@ -56,7 +56,7 @@ func RunTestQueryFlushing(t *testing.T, query QueryFunc) {
 	if len(flushed) == 0 {
 		t.Fatal("Flushed query was empty")
 	}
-	calculated, err := helperMakeStatPoints(data, width)
+	calculated, err := helperMakeStatPoints(data, start, width)
 	if err != nil {
 		t.Fatalf("Error calculating expected query results: %v\n", err)
 	}

--- a/tests/window_query_test.go
+++ b/tests/window_query_test.go
@@ -49,7 +49,13 @@ func RunTestQueryFlushing(t *testing.T, query QueryFunc) {
 	if err != nil {
 		t.Fatalf("Error from Flush %v", err)
 	}
+	if len(unflushed) == 0 {
+		t.Fatal("Unflushed query was empty")
+	}
 	flushed, _, _ := query(t, ctx, stream, start, end, count)
+	if len(flushed) == 0 {
+		t.Fatal("Flushed query was empty")
+	}
 	err = helperCheckStatisticalEqual(unflushed, flushed)
 	if err != nil {
 		t.Fatal("Flushed and unflushed queries were not equal.")

--- a/tests/window_query_test.go
+++ b/tests/window_query_test.go
@@ -56,17 +56,17 @@ func RunTestQueryFlushing(t *testing.T, query QueryFunc) {
 	if len(flushed) == 0 {
 		t.Fatal("Flushed query was empty")
 	}
-	err = helperCheckStatisticalEqual(unflushed, flushed)
+	calculated, err := helperMakeStatPoints(data, width)
 	if err != nil {
-		t.Fatal("Flushed and unflushed queries were not equal.")
+		t.Fatalf("Error calculating expected query results: %v\n", err)
 	}
-	err = helperCheckStatisticalCorrect(data, unflushed, width)
+	err = helperCheckStatisticalEqual(unflushed, calculated)
 	if err != nil {
-		t.Fatalf("Flushed results did not match generated data: %v", err)
+		t.Fatalf("Unflushed and calculated queries were not equal: %v", err)
 	}
-	err = helperCheckStatisticalCorrect(data, flushed, width)
+	err = helperCheckStatisticalEqual(flushed, calculated)
 	if err != nil {
-		t.Fatalf("Unflushed results did not match generated data: %v", err)
+		t.Fatalf("Flushed and calculated queries were not equal: %v", err)
 	}
 }
 

--- a/tests/window_query_test.go
+++ b/tests/window_query_test.go
@@ -1,0 +1,86 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"gopkg.in/BTrDB/btrdb.v4"
+)
+
+type QueryFunc func(t *testing.T, ctx context.Context, s *btrdb.Stream, start int64, end int64, count int64) ([]btrdb.StatPoint, uint64, int64)
+
+func RunTestQueryWithHoles(t *testing.T, query QueryFunc) {
+	ctx := context.Background()
+	db := helperConnect(t, ctx)
+	stream := helperCreateDefaultStream(t, ctx, db, nil, nil)
+	start := int64(1519088910) // Random unix datetime
+	midEnd := start + 1000000
+	midStart := midEnd + 100000
+	finalEnd := midStart + 1000000
+	count := int64(100000)
+	firstData := helperRandomDataCount(start, midEnd, count)
+	helperInsert(t, ctx, stream, firstData)
+	secondData := helperRandomDataCount(midStart, finalEnd, count)
+	helperInsert(t, ctx, stream, secondData)
+	spts, _, width := query(t, ctx, stream, start, finalEnd, count*2)
+	allData := make([]btrdb.RawPoint, 0)
+	allData = append(allData, firstData...)
+	allData = append(allData, secondData...)
+	err := helperCheckStatisticalCorrect(allData, spts, int64(width))
+	if err != nil {
+		t.Fatalf("Queried data was invalid: %v", err)
+	}
+}
+
+func RunTestQueryFlushing(t *testing.T, query QueryFunc) {
+	ctx := context.Background()
+	db := helperConnect(t, ctx)
+	stream := helperCreateDefaultStream(t, ctx, db, nil, nil)
+	start := int64(1519088910) // Random unix datetime
+	end := start + 1000000
+	count := int64(100000)
+	data := helperRandomDataCount(start, end, count)
+	err := stream.Insert(ctx, data)
+	if err != nil {
+		t.Fatalf("Error from insert %v", err)
+	}
+	unflushed, _, _ := query(t, ctx, stream, start, end, count)
+	err = stream.Flush(ctx)
+	if err != nil {
+		t.Fatalf("Error from Flush %v", err)
+	}
+	flushed, _, _ := query(t, ctx, stream, start, end, count)
+	err = helperCheckStatisticalEqual(unflushed, flushed)
+	if err != nil {
+		t.Fatal("Flushed and unflushed queries were not equal.")
+	}
+}
+
+func doWindowsQuery(t *testing.T, ctx context.Context, s *btrdb.Stream, start int64, end int64, count int64) ([]btrdb.StatPoint, uint64, int64) {
+	width := int64(end - start)
+	result, version := helperWindowQuery(t, ctx, s, start, end+width, uint64(width), 0, 0)
+	return result, version, width
+}
+
+func doAlignedWindowsQuery(t *testing.T, ctx context.Context, s *btrdb.Stream, start int64, end int64, count int64) ([]btrdb.StatPoint, uint64, int64) {
+	pwe := uint8(48)
+	width := int64(1) << pwe
+	result, version := helperStatisticalQuery(t, ctx, s, start, end+width, pwe, 0)
+	return result, version, width
+}
+
+func TestWindowsQueryWithHole(t *testing.T) {
+	RunTestQueryWithHoles(t, doWindowsQuery)
+}
+
+func TestAlignedWindowsQueryWithHole(t *testing.T) {
+	RunTestQueryWithHoles(t, doAlignedWindowsQuery)
+}
+
+func TestWindowsQueryFlushing(t *testing.T) {
+	RunTestQueryFlushing(t, doWindowsQuery)
+}
+
+func TestAlignedWindowsQueryFlushing(t *testing.T) {
+	RunTestQueryFlushing(t, doAlignedWindowsQuery)
+}

--- a/tests/window_query_test.go
+++ b/tests/window_query_test.go
@@ -44,7 +44,7 @@ func RunTestQueryFlushing(t *testing.T, query QueryFunc) {
 	if err != nil {
 		t.Fatalf("Error from insert %v", err)
 	}
-	unflushed, _, _ := query(t, ctx, stream, start, end, count)
+	unflushed, _, width := query(t, ctx, stream, start, end, count)
 	err = stream.Flush(ctx)
 	if err != nil {
 		t.Fatalf("Error from Flush %v", err)
@@ -59,6 +59,14 @@ func RunTestQueryFlushing(t *testing.T, query QueryFunc) {
 	err = helperCheckStatisticalEqual(unflushed, flushed)
 	if err != nil {
 		t.Fatal("Flushed and unflushed queries were not equal.")
+	}
+	err = helperCheckStatisticalCorrect(data, unflushed, width)
+	if err != nil {
+		t.Fatalf("Flushed results did not match generated data: %v", err)
+	}
+	err = helperCheckStatisticalCorrect(data, flushed, width)
+	if err != nil {
+		t.Fatalf("Unflushed results did not match generated data: %v", err)
 	}
 }
 


### PR DESCRIPTION
In the process of writing these tests I found some of the helper functions in `corners_test.go` useful, so I refactored them out into their own file. Let me know if I should refactor the rest into this file.

I also added 4 tests, testing both windows queries with two scenarios, one where the data has a hole in the middle, and one checking the equality of flushed and unflushed data.