### PR TITLE
Fix test stat point generation for various aligned/unaligned cases

### DIFF
--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -95,7 +95,7 @@ func helperMakeStatPoints(points []btrdb.RawPoint, start int64, end int64, query
 
 		/* For aligned queries, queryWidth will be 1<<pw,
 		 * and we want to clear the pw bits from the window start
-		 * (i.e. start & ~((1<<pw) - 1)
+		 * ( e.g. start & ~((1<<pw) - 1) )
 		 */
 		if aligned {
 			windowStart = windowStart &^ (queryWidth - 1)
@@ -127,8 +127,7 @@ func helperMakeStatPoints(points []btrdb.RawPoint, start int64, end int64, query
 		index = offset
 	}
 
-	/*
-	 * Unaligned queries always return the corrent number of stat
+	/* Unaligned queries always return the correct number of stat
 	 * points, even if there is no data
 	 */
 	for !aligned && len(statPoints) < numPoints {

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -107,7 +107,9 @@ func helperMakeStatPoints(points []btrdb.RawPoint, start int64, end int64, query
 
 		pointsSlice := points[index:offset]
 
-		// Unaligned queries return empty stat points
+		/* Unaligned queries return empty stat points
+		 * even if there is no data
+		 */
 		if !aligned && len(pointsSlice) == 0 {
 			empty := btrdb.StatPoint{windowStart, 0, 0, 0, 0}
 			statPoints = append(statPoints, empty)
@@ -128,7 +130,7 @@ func helperMakeStatPoints(points []btrdb.RawPoint, start int64, end int64, query
 	}
 
 	/* Unaligned queries always return the correct number of stat
-	 * points, even if there is no data
+	 * points, even if the end extends past the data
 	 */
 	for !aligned && len(statPoints) < numPoints {
 		windowStart := start + int64(len(statPoints))*queryWidth

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -82,7 +82,7 @@ func helperFloatEquals(x float64, y float64) bool {
 	return math.Abs(x-y) < 1e-10*math.Max(math.Abs(x), math.Abs(y))
 }
 
-func helperMakeStatPoints(points []btrdb.RawPoint, queryStart int64, queryWidth int64) ([]btrdb.StatPoint, error) {
+func helperMakeStatPoints(points []btrdb.RawPoint, queryStart int64, queryWidth int64) []btrdb.StatPoint {
 	numPoints := (points[len(points)-1].Time - queryStart) / queryWidth
 	statPoints := make([]btrdb.StatPoint, numPoints)
 	offset := 0
@@ -111,14 +111,11 @@ func helperMakeStatPoints(points []btrdb.RawPoint, queryStart int64, queryWidth 
 		statPoints = append(statPoints, statPoint)
 		offset = end + 1
 	}
-	return statPoints, nil
+	return statPoints
 }
 
 func helperCheckStatisticalCorrect(points []btrdb.RawPoint, statPoints []btrdb.StatPoint, queryStart int64, queryWidth int64) error {
-	calculated, err := helperMakeStatPoints(points, queryStart, queryWidth)
-	if err != nil {
-		return err
-	}
+	calculated := helperMakeStatPoints(points, queryStart, queryWidth)
 	return helperCheckStatisticalEqual(calculated, statPoints)
 }
 

--- a/tests/window_query_test.go
+++ b/tests/window_query_test.go
@@ -2,10 +2,10 @@ package tests
 
 import (
 	"context"
-	"fmt"
+	//"fmt"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
+	//"github.com/davecgh/go-spew/spew"
 	"gopkg.in/BTrDB/btrdb.v4"
 )
 
@@ -109,14 +109,14 @@ func RunTestQueryFlushing(t *testing.T, q Queryable, scount int) {
 		t.Fatal("Flushed query was empty")
 	}
 	calculated := q.MakeStatPoints(data, start, end, width)
-	//This is here to help debug the test, at the moment it is not correct
-	//as it does not calculate empty windows
-	fmt.Printf("calculated:\n")
-	spew.Dump(calculated)
-	fmt.Printf("unflushed:\n")
-	spew.Dump(unflushed)
-	fmt.Printf("flushed:\n")
-	spew.Dump(flushed)
+	/*
+		fmt.Printf("calculated:\n")
+		spew.Dump(calculated)
+		fmt.Printf("unflushed:\n")
+		spew.Dump(unflushed)
+		fmt.Printf("flushed:\n")
+		spew.Dump(flushed)
+	*/
 	err = helperCheckStatisticalEqual(unflushed, calculated)
 	if err != nil {
 		t.Fatalf("Unflushed and calculated queries were not equal: %v", err)

--- a/tests/window_query_test.go
+++ b/tests/window_query_test.go
@@ -25,14 +25,14 @@ func (awq AlignedWindowsQuery) GetContext() context.Context {
 }
 
 func (awq AlignedWindowsQuery) DoQuery(s *btrdb.Stream, start int64, end int64, count int64) ([]btrdb.StatPoint, uint64, int64) {
-	pwe := uint8(48)
+	pwe := uint8(52)
 	width := int64(1) << pwe
 	result, version := helperStatisticalQuery(awq.t, awq.ctx, s, start, end+width, pwe, 0)
 	return result, version, width
 }
 
 func (awq AlignedWindowsQuery) MakeStatPoints(points []btrdb.RawPoint, start int64, end, width int64) []btrdb.StatPoint {
-	return helperMakeStatPoints(points, start, end, width, false)
+	return helperMakeStatPoints(points, start, end, width, true)
 }
 
 type WindowsQuery struct {
@@ -45,13 +45,13 @@ func (wq WindowsQuery) GetContext() context.Context {
 }
 
 func (wq WindowsQuery) DoQuery(s *btrdb.Stream, start int64, end int64, count int64) ([]btrdb.StatPoint, uint64, int64) {
-	width := int64(end - start)
+	width := int64(end-start) / 4
 	result, version := helperWindowQuery(wq.t, wq.ctx, s, start, end+width, uint64(width), 0, 0)
 	return result, version, width
 }
 
 func (wq WindowsQuery) MakeStatPoints(points []btrdb.RawPoint, start int64, end int64, width int64) []btrdb.StatPoint {
-	return helperMakeStatPoints(points, start, end, width, true)
+	return helperMakeStatPoints(points, start, end, width, false)
 }
 
 func RunTestQueryWithHoles(t *testing.T, q Queryable, scount int) {


### PR DESCRIPTION
Addresses some of the outstanding issues from the previous PR such as:
* Stat point equality function was not checking that the window times were the same
* Unaligned windows query was using the first point in the range instead of the actual window start time
* Stat point generation did not make empty stat points for unaligned queries
* Stat point generation was not clearing the bottom bit of the window start time for aligned queries