### PR TITLE
Add tests for duplicate timestamps issue

### DIFF
--- a/tests/duplicate_timestamps_test.go
+++ b/tests/duplicate_timestamps_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"gopkg.in/BTrDB/btrdb.v4"
 	"testing"
+	"time"
 )
 
 func TestInsertDuplciateTimestampsErrors(t *testing.T) {
@@ -20,12 +21,13 @@ func TestInsertDuplciateTimestampsErrors(t *testing.T) {
 		t.Fatalf("Error inserting normal data: %v", err)
 	}
 
-	duplicateData := make([]btrdb.RawPoint, 100000)
+	duplicateData := make([]btrdb.RawPoint, 50000)
 	for i, _ := range duplicateData {
 		point := btrdb.RawPoint{start, 555}
 		duplicateData[i] = point
 	}
-	err = secondStream.Insert(ctx, duplicateData)
+	timedCtx, _ := context.WithTimeout(ctx, 1*time.Second)
+	err = secondStream.Insert(timedCtx, duplicateData)
 	if err != nil {
 		t.Fatalf("Error inserting normal data: %v", err)
 	}

--- a/tests/duplicate_timestamps_test.go
+++ b/tests/duplicate_timestamps_test.go
@@ -14,14 +14,15 @@ func TestInsertDuplciateTimestampsErrors(t *testing.T) {
 	firstStream := helperCreateDefaultStream(t, ctx, db, nil, nil)
 	secondStream := helperCreateDefaultStream(t, ctx, db, nil, nil)
 	start := int64(1524520800000)
-	normalData := helperRandomDataCount(start, start+100, 100)
+	end := start + 100
+	normalData := helperRandomDataCount(start, end, 100)
 
 	err := firstStream.Insert(ctx, normalData)
 	if err != nil {
 		t.Fatalf("Error inserting normal data: %v", err)
 	}
 
-	duplicateData := make([]btrdb.RawPoint, 50000)
+	duplicateData := make([]btrdb.RawPoint, 1000)
 	for i, _ := range duplicateData {
 		point := btrdb.RawPoint{start, 555}
 		duplicateData[i] = point
@@ -29,6 +30,20 @@ func TestInsertDuplciateTimestampsErrors(t *testing.T) {
 	timedCtx, _ := context.WithTimeout(ctx, 1*time.Second)
 	err = secondStream.Insert(timedCtx, duplicateData)
 	if err != nil {
-		t.Fatalf("Error inserting normal data: %v", err)
+		t.Fatalf("Error inserting duplicate timestamp data: %v", err)
+	}
+
+	pc, _, errc := firstStream.RawValues(ctx, start, end, 0)
+	err = <-errc
+	if err != nil {
+		t.Fatalf("Failed querying first stream after duplicate insert: %v", err)
+	}
+
+	rv := make([]btrdb.RawPoint, 0)
+	for p := range pc {
+		rv = append(rv, p)
+	}
+	if len(rv) != len(normalData) {
+		t.Fatal("Queried data len was different from original data len")
 	}
 }

--- a/tests/duplicate_timestamps_test.go
+++ b/tests/duplicate_timestamps_test.go
@@ -1,0 +1,32 @@
+package tests
+
+import (
+	"context"
+	"gopkg.in/BTrDB/btrdb.v4"
+	"testing"
+)
+
+func TestInsertDuplciateTimestampsErrors(t *testing.T) {
+	ctx := context.Background()
+	db := helperConnect(t, ctx)
+
+	firstStream := helperCreateDefaultStream(t, ctx, db, nil, nil)
+	secondStream := helperCreateDefaultStream(t, ctx, db, nil, nil)
+	start := int64(1524520800000)
+	normalData := helperRandomDataCount(start, start+100, 100)
+
+	err := firstStream.Insert(ctx, normalData)
+	if err != nil {
+		t.Fatalf("Error inserting normal data: %v", err)
+	}
+
+	duplicateData := make([]btrdb.RawPoint, 100000)
+	for i, _ := range duplicateData {
+		point := btrdb.RawPoint{start, 555}
+		duplicateData[i] = point
+	}
+	err = secondStream.Insert(ctx, duplicateData)
+	if err != nil {
+		t.Fatalf("Error inserting normal data: %v", err)
+	}
+}

--- a/tests/duplicate_timestamps_test.go
+++ b/tests/duplicate_timestamps_test.go
@@ -27,8 +27,9 @@ func TestInsertDuplciateTimestampsErrors(t *testing.T) {
 		point := btrdb.RawPoint{start, 555}
 		duplicateData[i] = point
 	}
-	timedCtx, _ := context.WithTimeout(ctx, 1*time.Second)
+	timedCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	err = secondStream.Insert(timedCtx, duplicateData)
+	cancel()
 	if err != nil {
 		t.Fatalf("Error inserting duplicate timestamp data: %v", err)
 	}


### PR DESCRIPTION
This was just sitting around, forgot to submit the PR.

I was hitting an issue with higher duplicate point counts where the insert would just take forever, so I added a timeout to hopefully fail the test sooner.