### PR TITLE
Adds earliest and latest helper functions

### DIFF
--- a/api.go
+++ b/api.go
@@ -20,10 +20,15 @@ package btrdb
 
 import (
 	"context"
-	"time"
 
 	"github.com/pborman/uuid"
 	pb "gopkg.in/BTrDB/btrdb.v5/v5api"
+)
+
+// Maximum window of time that can be stored in a BTrDB tree
+const (
+	MinimumTime = -(16 << 56)
+	MaximumTime = (48 << 56)
 )
 
 //OptKV is a utility function for use in SetAnnotations or LookupStreams that
@@ -542,6 +547,9 @@ func (s *Stream) Nearest(ctx context.Context, time int64, version uint64, backwa
 // returned point will be >= after. This function is therefore essentially synonymous with the
 // Nearest function.
 func (s *Stream) Earliest(ctx context.Context, after int64, version uint64) (rv RawPoint, ver uint64, err error) {
+	if after == 0 {
+		after = MinimumTime
+	}
 	return s.Nearest(ctx, after, version, false)
 }
 
@@ -550,7 +558,7 @@ func (s *Stream) Earliest(ctx context.Context, after int64, version uint64) (rv 
 // as the starting point to search from.
 func (s *Stream) Latest(ctx context.Context, before int64, version uint64) (rv RawPoint, ver uint64, err error) {
 	if before == 0 {
-		before = time.Now().UnixNano()
+		before = MaximumTime
 	}
 	return stream.Nearest(ctx, before, version, true)
 }

--- a/api.go
+++ b/api.go
@@ -550,7 +550,7 @@ func (s *Stream) Earliest(ctx context.Context, after int64, version uint64) (rv 
 }
 
 // Latest returns the point nearest to the specified end time, searching backward such that the
-// returned point will be <= before. To find the latest point that exists in a stream, use:
+// returned point will be < before. To find the latest point that exists in a stream, use:
 // stream.Latest(context.Background(), btrdb.MaximumTime, 0). Another common usage is to find the
 // point closest to now: stream.Latest(context.Background(), time.Now().UnixNano(), 0)
 func (s *Stream) Latest(ctx context.Context, before int64, version uint64) (rv RawPoint, ver uint64, err error) {

--- a/api.go
+++ b/api.go
@@ -28,7 +28,7 @@ import (
 // Maximum window of time that can be stored in a BTrDB tree
 const (
 	MinimumTime = -(16 << 56)
-	MaximumTime = (48 << 56)
+	MaximumTime = (48 << 56) - 1
 )
 
 //OptKV is a utility function for use in SetAnnotations or LookupStreams that
@@ -169,8 +169,7 @@ func (s *Stream) Tags(ctx context.Context) (map[string]*string, error) {
 	return s.tags, nil
 }
 
-//If a stream has changed tags, you will need to call this to load the new
-//tags
+// If a stream has changed tags, you will need to call this to load the new tags
 func (s *Stream) Refresh(ctx context.Context) error {
 	return s.refreshMeta(ctx)
 }
@@ -544,23 +543,18 @@ func (s *Stream) Nearest(ctx context.Context, time int64, version uint64, backwa
 }
 
 // Earliest returns the point nearest to the specified start time searching forward such that the
-// returned point will be >= after. This function is therefore essentially synonymous with the
-// Nearest function.
+// returned point will be >= after. To find the earliest point that exists in a stream, use:
+// stream.Earliest(context.Background(), btrdb.MinimumTime, 0).
 func (s *Stream) Earliest(ctx context.Context, after int64, version uint64) (rv RawPoint, ver uint64, err error) {
-	if after == 0 {
-		after = MinimumTime
-	}
 	return s.Nearest(ctx, after, version, false)
 }
 
 // Latest returns the point nearest to the specified end time, searching backward such that the
-// returned point will be <= before. If before is not specified, then the current timestamp is used
-// as the starting point to search from.
+// returned point will be <= before. To find the latest point that exists in a stream, use:
+// stream.Latest(context.Background(), btrdb.MaximumTime, 0). Another common usage is to find the
+// point closest to now: stream.Latest(context.Background(), time.Now().UnixNano(), 0)
 func (s *Stream) Latest(ctx context.Context, before int64, version uint64) (rv RawPoint, ver uint64, err error) {
-	if before == 0 {
-		before = MaximumTime
-	}
-	return stream.Nearest(ctx, before, version, true)
+	return s.Nearest(ctx, before, version, true)
 }
 
 func (s *Stream) Changes(ctx context.Context, fromVersion uint64, toVersion uint64, resolution uint8) (crv chan ChangedRange, cver chan uint64, cerr chan error) {

--- a/api.go
+++ b/api.go
@@ -20,6 +20,7 @@ package btrdb
 
 import (
 	"context"
+	"time"
 
 	"github.com/pborman/uuid"
 	pb "gopkg.in/BTrDB/btrdb.v5/v5api"
@@ -535,6 +536,23 @@ func (s *Stream) Nearest(ctx context.Context, time int64, version uint64, backwa
 		rv, ver, err = ep.Nearest(ctx, s.uuid, time, version, backward)
 	}
 	return
+}
+
+// Earliest returns the point nearest to the specified start time searching forward such that the
+// returned point will be >= after. This function is therefore essentially synonymous with the
+// Nearest function.
+func (s *Stream) Earliest(ctx context.Context, after int64, version uint64) (rv RawPoint, ver uint64, err error) {
+	return s.Nearest(ctx, after, version, false)
+}
+
+// Latest returns the point nearest to the specified end time, searching backward such that the
+// returned point will be <= before. If before is not specified, then the current timestamp is used
+// as the starting point to search from.
+func (s *Stream) Latest(ctx context.Context, before int64, version uint64) (rv RawPoint, ver uint64, err error) {
+	if before == 0 {
+		before = time.Now().UnixNano()
+	}
+	return stream.Nearest(ctx, before, version, true)
 }
 
 func (s *Stream) Changes(ctx context.Context, fromVersion uint64, toVersion uint64, resolution uint8) (crv chan ChangedRange, cver chan uint64, cerr chan error) {


### PR DESCRIPTION
These are essentially wrapper functions for `Nearest` but may be a bit more intuitive to users. Note that `Latest` is bound to the present, RE: our discussion in CH.